### PR TITLE
README.md: Add link to jaseg's router configuration guid

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,10 @@
 # "Hacking" the (Telekom) Zyxel GPON SFP module (PMG3000-D20B)
 > The SFP can be sourced very easily and is widely available in Germany.
 
+## I just want fiber internet on my non-Telekom router
+
+[jaseg](https://github.com/jaseg/) has written a guide on this [on his blog](https://blog.jaseg.de/posts/telekom-gpon-sfp/).
+
 ## TLDR
 
 Checkout the three options for configuring your SFP.


### PR DESCRIPTION
I wrote up a short guide on how to configure an Ubiquiti EdgeRouter since the part where you first have to access the SFP module's web interface to set the SLID/PLOAM pw, then configure PPPoE on the same interface is not obvious.