### PR TITLE
Add instructions to enable 2.5G

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -258,6 +258,13 @@ admin@SFP:~# onu ploamsg
 errorcode=0 curr_state=1 previous_state=0 elapsed_msec=16907701
 ```
 
+## Enable 2.5G
+2.5G may not be enabled by default on the SFP. Use the following command to enable 2.5 manually:
+```
+ZYXEL# hal
+Hal# set speed 2.5g mode full
+```
+
 ## HTTP API
 
 Only after getting SSH access I discovered the SFP comes with a WebUI and a _sort of_ API. The CLI `zyxel_gpon_sfp.py` makes use of this API to remotely configure the PLOAM password and possibly SN (again, didn't check it).

--- a/Readme.md
+++ b/Readme.md
@@ -265,6 +265,8 @@ ZYXEL# hal
 Hal# set speed 2.5g mode full
 ```
 
+You may have to disable auto-negotation and set a fixed port speed of 2.5G on your network adapter to make it work.
+
 ## HTTP API
 
 Only after getting SSH access I discovered the SFP comes with a WebUI and a _sort of_ API. The CLI `zyxel_gpon_sfp.py` makes use of this API to remotely configure the PLOAM password and possibly SN (again, didn't check it).


### PR DESCRIPTION
This PR adds an instruction how to enable 2.5G on the GPON-SFP in case it isn't enabled by default.

The Zyxel PMG3000-D20B SFPs I bought directly from a distributor had a default port speed of 1G and wasn't able to use 2.5G until I configured the speed manually using the CLI.